### PR TITLE
Refactor monitor script for robustness and default data

### DIFF
--- a/.github/workflows/monitor.qmd
+++ b/.github/workflows/monitor.qmd
@@ -27,7 +27,7 @@ permissions:
 ...
 
 # Load data
-results_json_path <- "../../data/results.json" # Path relative to the QMD file
+results_json_path <- "../../docs/data/results.json" # Path relative to the QMD file
 
 if (!file.exists(results_json_path)) {
   cat("Error: `data/results.json` not found at `", results_json_path, "`. Please ensure the monitor script has run successfully and the path is correct relative to the Quarto document.\n")

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -34,14 +34,11 @@ except Exception as e:
 # Configuration
 ping_targets_env = os.getenv("PING_TARGETS")
 if not ping_targets_env:
-    logging.error("PING_TARGETS environment variable is not set or empty. Please set it to a comma-separated list of targets.")
-    # Defaulting to a predefined list as per potential future enhancement, but exiting for now.
-    # targets = ["google.com", "8.8.8.8"]
-    # logging.info(f"Using default targets: {targets}")
-    exit(1) # Exit if not set, as per current requirements
-
-targets = [target.strip() for target in ping_targets_env.split(',')]
-logging.info(f"Targets to ping: {targets}")
+    targets = ["google.com", "github.com"]
+    logging.warning(f"PING_TARGETS environment variable is not set or empty. Using default targets: {targets}")
+else:
+    targets = [target.strip() for target in ping_targets_env.split(',')]
+    logging.info(f"Targets to ping: {targets}")
 
 # logfile = os.path.join(os.getcwd(), "status_log.csv") # Existing log file for single host status - REMOVED
 # logging.info(f"Legacy log file path (single host status): {logfile}") - REMOVED
@@ -114,11 +111,24 @@ def main():
     logging.info("Completed processing all targets.")
     logging.info(f"Aggregated ping results (in-memory): {ping_results}")
 
-    # Create 'data/' directory and write results to 'data/results.json'
-    results_file_path = "data/results.json"
+    # Ensure data/results.json is always created with some content
+    if not ping_results:
+        logging.info("No ping results were collected. Generating pseudo-data for default targets.")
+        current_time_iso = datetime.utcnow().isoformat()
+        default_fallback_targets = ["google.com", "github.com"]
+        for target_host in default_fallback_targets:
+            ping_results.append({
+                "resource": target_host,
+                "status": "Unknown",
+                "timestamp": current_time_iso
+            })
+        logging.debug(f"Generated pseudo-data: {ping_results}")
+
+    # Create 'docs/data/' directory and write results to 'docs/data/results.json'
+    results_file_path = "docs/data/results.json"
     try:
-        os.makedirs("data", exist_ok=True)
-        logging.info(f"Ensured 'data' directory exists.")
+        os.makedirs("docs/data", exist_ok=True)
+        logging.info(f"Ensured 'docs/data' directory exists.")
         with open(results_file_path, "w") as f:
             json.dump(ping_results, f, indent=2)
         logging.info(f"Successfully wrote ping results to {results_file_path}")


### PR DESCRIPTION
This commit introduces several improvements to the monitor.py script:

- Handles missing PING_TARGETS: If the PING_TARGETS environment variable is not set, the script now defaults to pinging "google.com" and "github.com".
- Generates pseudo-data: If no ping results are collected (e.g., all pings fail or PING_TARGETS was initially empty and default pings also fail), the script now generates placeholder data with an "Unknown" status for the default targets. This ensures that results.json always has content with a consistent structure.
- Ensures default sparklines: Sparkline images are generated for default targets when they are used. The "Unknown" status will be rendered as "Down" in the current sparkline logic.
- Relocates results.json: The ping results are now saved to docs/data/results.json to be more aligned with Quarto's output directory structure. The monitor.qmd file has been updated to reflect this new path.

These changes enhance the reliability of the monitoring dashboard by ensuring that data files are always present, even in minimal or default configurations, and by providing clearer fallback states.